### PR TITLE
Orange Pi * HDMI->DVI support and comment translation

### DIFF
--- a/sys_config/h3/orange_pi2.fex
+++ b/sys_config/h3/orange_pi2.fex
@@ -491,9 +491,9 @@ fb1_height               = 0
 [hdmi_para]
 hdmi_used           = 1
 hdmi_power          = "vcc-hdmi-18"
-;-------------------------------------
-; set to 0 for hdmi->dvi compatibility
-;-------------------------------------
+;----------------------------------------------------------------------------------
+; uncomment for hdmi->dvi adapter, comment for direct hdmi
+;----------------------------------------------------------------------------------
 ;hdcp_enable            = 0
 ;hdmi_cts_compatibility = 1
 

--- a/sys_config/h3/orange_pi2.fex
+++ b/sys_config/h3/orange_pi2.fex
@@ -491,6 +491,11 @@ fb1_height               = 0
 [hdmi_para]
 hdmi_used           = 1
 hdmi_power          = "vcc-hdmi-18"
+;-------------------------------------
+; set to 0 for hdmi->dvi compatibility
+;-------------------------------------
+;hdcp_enable            = 0
+;hdmi_cts_compatibility = 1
 
 [tv_para]
 tv_used				= 1

--- a/sys_config/h3/orange_pi_plus.fex
+++ b/sys_config/h3/orange_pi_plus.fex
@@ -170,9 +170,9 @@ pll_de           = 864
 ;*****************************************************************************
 ;sdram configuration
 ;
-;dram_para2 = 0x00001200  ;代表启用dram双通道
+;dram_para2 = 0x00001200  ;Representative enable dram Dual
 ;
-;dram_para2 = 0x00001100  ;代表启用dram单通道
+;dram_para2 = 0x00001100  ;on behalf of a single channel is enabled dram
 ;
 ;*****************************************************************************
 [dram_para]
@@ -777,16 +777,16 @@ smc_sda             = port:PA08<2><default><default><default>
 
 
 ;--------------------------------
-;[usbc0]：控制器0的配置。
-;usb_used：USB使能标志。置1，表示系统中USB模块可用,置0,则表示系统USB禁用。
-;usb_port_type：USB端口的使用情况。 0：device only;1：host only;2：OTG
-;usb_detect_type：USB端口的检查方式。0：不做检测;1：vbus/id检查;2：id/dpdm检查
-;usb_id_gpio：USB ID pin脚配置。具体请参考gpio配置说明。
-;usb_det_vbus_gpio：USB DET_VBUS pin脚配置。具体请参考gpio配置说明。
-;usb_drv_vbus_gpio：USB DRY_VBUS pin脚配置。具体请参考gpio配置说明。
-;usb_det_vbus_gpio: "axp_ctrl",表示axp 提供
-;usb_restrict_gpio  usb限流控制pin
-;usb_restric_flag:  usb限流标置
+; [usbc0]: Controller 0 configuration.
+; usb used:          USB enable flag. Set, indicating that the system USB module is available, is set to 0, it means that the system USB is disabled.
+; usb_port_type:     USB port usage. 0: device only; 1: host only; 2: OTG
+; usb_detect_type:   USB port of checking. 0: not detected; 1: vbus / id checks; 2: id / dpdm check
+; usb_id_gpio:       USB ID pin pin configuration. For details, please refer gpio configuration instructions.
+; usb_det_vbus_gpio: USB DET_VBUS pin pin configuration. For details, please refer gpio configuration instructions.
+; usb_drv_vbus_gpio: USB DRY_VBUS pin pin configuration. For details, please refer gpio configuration instructions.
+; usb_det_vbus_gpio: "axp_ctrl", represents axp offer
+; usb_restrict_gpio: usb limiting control pin
+; usb_restric_flag:  usb limiting standard set
 ;--------------------------------
 ;--------------------------------
 ;---       USB0控制标志

--- a/sys_config/h3/orange_pi_plus.fex
+++ b/sys_config/h3/orange_pi_plus.fex
@@ -491,9 +491,9 @@ fb1_height               = 0
 [hdmi_para]
 hdmi_used           = 1
 hdmi_power          = "vcc-hdmi-18"
-;-------------------------------------
-; set to 0 for hdmi->dvi compatibility
-;-------------------------------------
+;----------------------------------------------------------------------------------
+; uncomment for hdmi->dvi adapter, comment for direct hdmi
+;----------------------------------------------------------------------------------
 ;hdcp_enable            = 0
 ;hdmi_cts_compatibility = 1
 

--- a/sys_config/h3/orange_pi_plus.fex
+++ b/sys_config/h3/orange_pi_plus.fex
@@ -491,6 +491,11 @@ fb1_height               = 0
 [hdmi_para]
 hdmi_used           = 1
 hdmi_power          = "vcc-hdmi-18"
+;-------------------------------------
+; set to 0 for hdmi->dvi compatibility
+;-------------------------------------
+;hdcp_enable            = 0
+;hdmi_cts_compatibility = 1
 
 [tv_para]
 tv_used				= 1

--- a/sys_config/h3/xunlong_orange_pi_pc.fex
+++ b/sys_config/h3/xunlong_orange_pi_pc.fex
@@ -347,9 +347,9 @@ fb1_height = 0
 [hdmi_para]
 hdmi_used = 1
 hdmi_power = "vcc-hdmi-18"
-;-------------------------------------
-; set to 0 for hdmi->dvi compatibility
-;-------------------------------------
+;----------------------------------------------------------------------------------
+; uncomment for hdmi->dvi adapter, comment for direct hdmi
+;----------------------------------------------------------------------------------
 ;hdcp_enable            = 0
 ;hdmi_cts_compatibility = 1
 

--- a/sys_config/h3/xunlong_orange_pi_pc.fex
+++ b/sys_config/h3/xunlong_orange_pi_pc.fex
@@ -347,6 +347,11 @@ fb1_height = 0
 [hdmi_para]
 hdmi_used = 1
 hdmi_power = "vcc-hdmi-18"
+;-------------------------------------
+; set to 0 for hdmi->dvi compatibility
+;-------------------------------------
+;hdcp_enable            = 0
+;hdmi_cts_compatibility = 1
 
 [tv_para]
 tv_used = 1


### PR DESCRIPTION
All of this except for the improved DVI blurb comes from the loboris tree. I suspect the settings for DVI may apply to all boards.
